### PR TITLE
Fix: BaseModal 훅 호출 순서 수정 ESlint오류 해결

### DIFF
--- a/src/components/common/modal/BaseModal.tsx
+++ b/src/components/common/modal/BaseModal.tsx
@@ -16,25 +16,27 @@ const BaseModal = ({
   describedById,
   panelClassName = '',
 }: BaseModalProps) => {
-  if (typeof document === 'undefined') return null
-  const root = modalUtils.getOrCreateRoot()
+  const isBrowser =
+    typeof window !== 'undefined' && typeof document !== 'undefined'
+  const root = isBrowser ? modalUtils.getOrCreateRoot() : null
 
   // ESC 닫기
   useEffect(() => {
-    if (!isOpen) return
+    if (!isBrowser || !isOpen) return
     const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-  }, [isOpen, onClose])
+  }, [isBrowser, isOpen, onClose])
 
   // body 스크롤 잠금
   useEffect(() => {
-    if (!isOpen) return
+    if (!isBrowser || !isOpen) return
     modalUtils.lockScroll()
     return () => modalUtils.unlockScroll()
-  }, [isOpen])
+  }, [isBrowser, isOpen])
 
-  if (!isOpen) return null
+  if (!isBrowser || !root || !isOpen) return null
+
   const { w, h } = MODAL_SIZES[size]
 
   return createPortal(


### PR DESCRIPTION
## 🚀 PR 요약

>React Hook(예: useEffect)을 조건문 안에서 호출했을 때 뜨는 ESLint 경고
맨 위의 if (typeof document === 'undefined') return null 때문에 훅(useEffect)이 조건부로 호출되는 것으로 간주돼서 에러가 남

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

<img width="399" height="56" alt="린트수정" src="https://github.com/user-attachments/assets/f7a890e9-2dc1-489a-8feb-d2d395bfd6b5" />


## 🔗 연관된 이슈

> closes #43 