### PR TITLE
Fix: TypeScript 경로와 Vite alias 수정하여 import 오류 해결

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,16 +26,16 @@
     "paths": {
       "@/*": ["./src/*"],
       "@api/*": ["./src/api/*"],
-      "@assets": ["./src/assets/index.ts"],
+      "@assets": ["./src/assets"],
       "@assets/*": ["./src/assets/*"],
-      "@components": ["./src/components/index.ts"],
+      "@components": ["./src/components"],
       "@components/*": ["./src/components/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@lib/*": ["./src/lib/*"],
       "@pages/*": ["./src/pages/*"],
       "@store/*": ["./src/store/*"],
       "@types/*": ["./src/types/*"],
-      "@utils": ["./src/utils/index.ts"],
+      "@utils": ["./src/utils"],
       "@utils/*": ["./src/utils/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,14 +11,14 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@api': path.resolve(__dirname, './src/api'),
-      '@assets': path.resolve(__dirname, './src/assets/index.ts'),
-      '@components': path.resolve(__dirname, './src/components/index.ts'),
+      '@assets': path.resolve(__dirname, './src/assets'),
+      '@components': path.resolve(__dirname, './src/components'),
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@lib': path.resolve(__dirname, './src/lib'),
       '@pages': path.resolve(__dirname, './src/pages'),
       '@store': path.resolve(__dirname, './src/store'),
       '@types': path.resolve(__dirname, './src/types'),
-      '@utils': path.resolve(__dirname, './src/utils/index.ts'),
+      '@utils': path.resolve(__dirname, './src/utils'),
     },
   },
 })


### PR DESCRIPTION
## 🚀 PR 요약

TypeScript 경로와 Vite alias 수정하여 import 오류 해결

## ✏️ 변경 유형

- [x] fix: 버그 수정

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🔗 연관된 이슈

> closes #54 
