### PR TITLE
Feature: breadcrumb 컴포넌트 제작

### DIFF
--- a/src/components/common/bread-crumb/BreadCrumb.tsx
+++ b/src/components/common/bread-crumb/BreadCrumb.tsx
@@ -1,0 +1,3 @@
+export default function BreadCrumb() {
+  return <div>BreadCrumb</div>
+}

--- a/src/components/common/bread-crumb/BreadCrumb.tsx
+++ b/src/components/common/bread-crumb/BreadCrumb.tsx
@@ -1,5 +1,5 @@
-import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import { Link } from 'react-router'
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
 
 interface BreadCrumbLinkItem {
   label: string
@@ -19,27 +19,28 @@ interface BreadCrumbProps {
 
 export default function BreadCrumb({ items }: BreadCrumbProps) {
   return (
-    <nav aria-label="breadCrumb" className="p-[25px] text-sm text-gray-600">
+    <nav
+      aria-label="breadCrumb"
+      className="max-w-[854px] p-[25px] text-sm text-gray-600"
+    >
       <ol className="flex">
         {items.map((item, i) => (
           <li
             key={'to' in item ? item.to : item.label}
-            className="flex items-center gap-2"
+            className="flex items-center gap-2 pl-2"
           >
             {'to' in item ? (
-              <Link to={item.to as string} className="pl-2">
-                {item.label}
-              </Link>
+              <Link to={item.to as string}>{item.label}</Link>
             ) : (
               <span
-                className="text-foreground pl-2 font-medium text-gray-900"
+                className="text-foreground font-medium text-gray-900"
                 aria-current="page"
               >
                 {item.label}
               </span>
             )}
             {i < items.length - 1 && (
-              <ChevronRightIcon className="text-muted-foreground h-4 w-4 pl-2" />
+              <ChevronRightIcon className="text-muted-foreground h-4 w-4" />
             )}
           </li>
         ))}

--- a/src/components/common/bread-crumb/BreadCrumb.tsx
+++ b/src/components/common/bread-crumb/BreadCrumb.tsx
@@ -1,3 +1,49 @@
-export default function BreadCrumb() {
-  return <div>BreadCrumb</div>
+import { ChevronRightIcon } from '@heroicons/react/24/outline'
+import { Link } from 'react-router'
+
+interface BreadCrumbLinkItem {
+  label: string
+  to: string | undefined
+}
+
+interface BreadCrumbCurrentItem {
+  label: string
+  to?: never
+}
+
+type BreadCrumbItem = BreadCrumbLinkItem | BreadCrumbCurrentItem
+
+interface BreadCrumbProps {
+  items: BreadCrumbItem[]
+}
+
+export default function BreadCrumb({ items }: BreadCrumbProps) {
+  return (
+    <nav aria-label="breadCrumb" className="p-[25px] text-sm text-gray-600">
+      <ol className="flex">
+        {items.map((item, i) => (
+          <li
+            key={'to' in item ? item.to : item.label}
+            className="flex items-center gap-2"
+          >
+            {'to' in item ? (
+              <Link to={item.to as string} className="pl-2">
+                {item.label}
+              </Link>
+            ) : (
+              <span
+                className="text-foreground pl-2 font-medium text-gray-900"
+                aria-current="page"
+              >
+                {item.label}
+              </span>
+            )}
+            {i < items.length - 1 && (
+              <ChevronRightIcon className="text-muted-foreground h-4 w-4 pl-2" />
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
 }

--- a/src/components/common/bread-crumb/index.ts
+++ b/src/components/common/bread-crumb/index.ts
@@ -1,0 +1,1 @@
+export { default as BreadCrumb } from '@/components/common/bread-crumb/BreadCrumb'


### PR DESCRIPTION
## 🚀 PR 요약

> 현재 페이지의 경로를 작게 상단에 보여주는 역할을 하는 컴포넌트입니다 

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항
 - route 경로 완성되면 수정 후 완성 예정입니다
> <img width="805" height="118" alt="image" src="https://github.com/user-attachments/assets/dfc7cf95-7626-4c4d-9018-660230f50e26" />

## 🔗 연관된 이슈

> closes #51 
