### PR TITLE
Feature: 스터디그룹 상세 페이지 반응형 디자인 적용 및 헤더 nav 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-hook-form": "^7.62.0",
         "react-responsive": "^10.0.1",
         "react-router": "^7.6.2",
+        "react-router-dom": "^7.9.1",
         "remark-breaks": "^4.0.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
@@ -7556,9 +7557,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
-      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
+      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7575,6 +7576,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
+      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-hook-form": "^7.62.0",
     "react-responsive": "^10.0.1",
     "react-router": "^7.6.2",
+    "react-router-dom": "^7.9.1",
     "remark-breaks": "^4.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -23,8 +23,10 @@ export default function Footer() {
                 {item.title}
               </H4>
               <ul className="flex flex-col gap-2 text-gray-300">
-                {item.list.map((li) => (
-                  <li key={li}>{li}</li>
+                {item.list.map((el) => (
+                  <li key={el.name}>
+                    <Link to={el.path}>{el.name}</Link>
+                  </li>
                 ))}
               </ul>
             </nav>

--- a/src/components/layout/header/HeaderNav.tsx
+++ b/src/components/layout/header/HeaderNav.tsx
@@ -1,3 +1,4 @@
+import { Link, useLocation } from 'react-router-dom'
 import { useMediaQuery } from 'react-responsive'
 
 import { HEADER_NAV_LISTS, mediaQuery } from '@constants'
@@ -5,12 +6,24 @@ import { cn } from '@utils'
 
 export default function HeaderNav() {
   const isMobile = useMediaQuery({ query: mediaQuery.mobile })
+  const { pathname } = useLocation()
 
   return (
     <nav>
       <ul className={cn('flex gap-8', isMobile && 'flex-col')}>
         {HEADER_NAV_LISTS.map((el) => (
-          <li key={el}>{el}</li>
+          <li key={el.name}>
+            <Link
+              to={el.path}
+              className={cn(
+                'text-gray-600 hover:text-gray-900',
+                pathname.startsWith(el.path) &&
+                  'text-primary-600 hover:text-primary-600 font-medium'
+              )}
+            >
+              {el.name}
+            </Link>
+          </li>
         ))}
       </ul>
     </nav>

--- a/src/components/study-group-detail/StudyGroupLecture.tsx
+++ b/src/components/study-group-detail/StudyGroupLecture.tsx
@@ -14,7 +14,7 @@ export default function StudyGroupLecture({
       titleVariant="base"
       titleClassName="pb-4 text-lg text-gray-900"
     >
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 sm:grid sm:grid-cols-2 lg:flex">
         {lecture?.map((el) => (
           <ImageCard
             key={el.title}

--- a/src/constants/navList.ts
+++ b/src/constants/navList.ts
@@ -1,4 +1,8 @@
-export const HEADER_NAV_LISTS = ['강의 목록', '스터디 그룹', '구인 공고']
+export const HEADER_NAV_LISTS = [
+  { name: '강의 목록', path: '/lectures' },
+  { name: '스터디 그룹', path: '/study-group' },
+  { name: '구인 공고', path: '/jobs' },
+]
 
 export const FOOTER_NAV_LISTS = [
   {
@@ -7,6 +11,10 @@ export const FOOTER_NAV_LISTS = [
   },
   {
     title: '지원',
-    list: ['고객센터', 'FAQ', '개인정보처리방침'],
+    list: [
+      { name: '고객센터', path: '/' },
+      { name: 'FAQ', path: '/' },
+      { name: '개인정보처리방침', path: '/' },
+    ],
   },
 ]

--- a/src/pages/StudyGroupDetail.tsx
+++ b/src/pages/StudyGroupDetail.tsx
@@ -19,7 +19,7 @@ export default function StudyGroupDetail() {
         currentUserRole={currentUserRole}
         isMember={isMember}
       />
-      <div className="mt-8 grid grid-cols-3 gap-8">
+      <div className="mt-8 gap-8 lg:grid lg:grid-cols-3">
         <div className="col-span-2">
           <StudyGroupLogList
             member={studyGroup.member}


### PR DESCRIPTION
## 🚀 PR 요약

스터디그룹 상세 페이지 반응형 디자인 적용
헤더 & 푸터 nav 기능 추가

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] style: 코드 포맷팅 등 스타일 변경

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

페이지 반응형 분기점은 sm, lg로 하였습니다.
'강의 목록' '구인 공고' path는 정확한 경로 나오면 수정하겠습니다.

<img width="1257" height="873" alt="image" src="https://github.com/user-attachments/assets/fcb0613e-0232-45d6-8c52-567f66c3238f" />
<img width="500" height="904" alt="image" src="https://github.com/user-attachments/assets/e8be692f-4fdb-4b47-a949-6abd68195695" />
<img width="300" height="901" alt="image" src="https://github.com/user-attachments/assets/82c1ca31-a76c-43b0-9ed0-9419baacd335" />


## 🔗 연관된 이슈

> closes #75 
