### PR TITLE
Fix: 이미지 카드 컴포넌트 이미지 비율 수정

### DIFF
--- a/src/components/common/image-card/ImageCard.tsx
+++ b/src/components/common/image-card/ImageCard.tsx
@@ -1,7 +1,6 @@
+import { cn } from '@utils'
 import { PhotoIcon } from '@heroicons/react/24/outline'
 import { type ComponentPropsWithoutRef, type ReactNode } from 'react'
-
-import { cn } from '@utils'
 
 interface ImageCardProps extends ComponentPropsWithoutRef<'div'> {
   title: string
@@ -18,19 +17,16 @@ export default function ImageCard({
 }: ImageCardProps) {
   return (
     <div
-      className={cn(
-        'relative flex flex-col overflow-hidden rounded-lg border border-gray-200',
-        className
-      )}
+      className="relative overflow-hidden rounded-lg border border-gray-200"
       {...rest}
     >
-      <header className="pt-32">
-        <div className="absolute inset-0 h-32 max-w-96">
+      <header>
+        <div className="aspect-[2/1] overflow-hidden rounded-t-lg">
           {imageUrl ? (
             <img
               src={imageUrl}
               alt={title}
-              className="bg-gray-200 object-cover"
+              className="h-full w-full bg-gray-200 object-cover"
             />
           ) : (
             <div className="flex h-full items-center justify-center bg-gray-200">
@@ -39,7 +35,7 @@ export default function ImageCard({
           )}
         </div>
       </header>
-      {children}
+      <div className={cn('flex flex-col', className)}>{children}</div>
     </div>
   )
 }

--- a/src/pages/StudyGroupDetail.tsx
+++ b/src/pages/StudyGroupDetail.tsx
@@ -20,15 +20,13 @@ export default function StudyGroupDetail() {
         currentUserRole={currentUserRole}
         isMember={isMember}
       />
-      <div className="mt-8 gap-8 lg:grid lg:grid-cols-3">
-        <div className="col-span-2 flex flex-col gap-8">
-          <div className="flex flex-col gap-8">
-            <StudyGroupSchedule schedule={studyGroup.schedule} />
-            <StudyGroupLogList
-              member={studyGroup.member}
-              studyLog={studyGroup.studyLog}
-            />
-          </div>
+      <div className="mt-6 flex flex-col gap-6 lg:mt-8 lg:grid lg:grid-cols-3">
+        <div className="col-span-2 flex flex-col gap-6 lg:gap-8">
+          <StudyGroupSchedule schedule={studyGroup.schedule} />
+          <StudyGroupLogList
+            member={studyGroup.member}
+            studyLog={studyGroup.studyLog}
+          />
         </div>
         <div className="flex flex-col gap-6">
           <StudyGroupInfo


### PR DESCRIPTION
## 🚀 PR 요약

이미지 카드 컴포넌트 이미지 비율 수정

## ✏️ 변경 유형

- [x] style: 코드 포맷팅 등 스타일 변경

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

수정 전)
<img width="646" height="408" alt="image" src="https://github.com/user-attachments/assets/5fa62ab0-8268-49c6-ae74-32e51ea318a8" />

수정 후)
<img width="300" height="734" alt="image" src="https://github.com/user-attachments/assets/2c3714dd-1199-4f21-8c26-9d6b2fe5f83d" />
<img width="550" height="497" alt="image" src="https://github.com/user-attachments/assets/1e30df0b-4058-4bc2-b20d-ec93ae1dd059" />


## 🔗 연관된 이슈

> closes #93 
