### PR TITLE
Feature: 스터디그룹 수정 페이지 컴포넌트 추가 및 라우트 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,20 @@ import { Route, Routes } from 'react-router'
 
 import './App.css'
 import { Layout } from '@components'
-import { StudyGroupDetail } from '@pages'
+import { StudyGroupDetail, StudyGroupEdit } from '@pages'
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Layout maxWidth="large" />}>
-        <Route path="study-group/:groupId" element={<StudyGroupDetail />} />
+      <Route path="/study-group" element={<Layout maxWidth="large" />}>
+        <Route path=":groupId" element={<StudyGroupDetail />} />
+      </Route>
+
+      <Route
+        path="/study-group"
+        element={<Layout maxWidth="medium" isBackgroundGray />}
+      >
+        <Route path=":groupId/edit" element={<StudyGroupEdit />} />
       </Route>
     </Routes>
   )

--- a/src/components/common/image-card/ImageCard.tsx
+++ b/src/components/common/image-card/ImageCard.tsx
@@ -1,6 +1,7 @@
-import { cn } from '@utils'
 import { PhotoIcon } from '@heroicons/react/24/outline'
 import { type ComponentPropsWithoutRef, type ReactNode } from 'react'
+
+import { cn } from '@utils'
 
 interface ImageCardProps extends ComponentPropsWithoutRef<'div'> {
   title: string

--- a/src/components/layout/header/HeaderNav.tsx
+++ b/src/components/layout/header/HeaderNav.tsx
@@ -1,5 +1,5 @@
-import { Link, useLocation } from 'react-router-dom'
 import { useMediaQuery } from 'react-responsive'
+import { Link, useLocation } from 'react-router-dom'
 
 import { HEADER_NAV_LISTS, mediaQuery } from '@constants'
 import { cn } from '@utils'

--- a/src/components/layout/layout/Layout.tsx
+++ b/src/components/layout/layout/Layout.tsx
@@ -5,13 +5,19 @@ import { cn } from '@utils'
 
 interface LayoutProps {
   maxWidth: 'medium' | 'large'
+  isBackgroundGray?: boolean
 }
 
-export default function Layout({ maxWidth }: LayoutProps) {
+export default function Layout({ maxWidth, isBackgroundGray }: LayoutProps) {
   return (
     <>
       <Header isLoggedin />
-      <main className="w-full pt-16 sm:px-20">
+      <main
+        className={cn(
+          'w-full pt-16 sm:px-20',
+          isBackgroundGray && 'bg-gray-50'
+        )}
+      >
         <div
           className={cn(
             'm-auto p-6 sm:p-8',

--- a/src/components/study-log/FileUpload.tsx
+++ b/src/components/study-log/FileUpload.tsx
@@ -9,8 +9,9 @@ import {
 } from '@components'
 import { MAX_FILE_COUNT } from '@constants'
 import { cn } from '@utils'
-import { UploadPlaceholder } from './UploadPlaceholder'
+
 import { UploadedFileList } from './UploadedFileList'
+import { UploadPlaceholder } from './UploadPlaceholder'
 
 interface FileUploadProps {
   onChange: (files: UploadedFile[]) => void

--- a/src/components/study-log/fileUpload.utils.ts
+++ b/src/components/study-log/fileUpload.utils.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
+
 import {
   ALLOWED_FILE_TYPES,
   ERROR_MESSAGES,

--- a/src/pages/StudyGroupEdit.tsx
+++ b/src/pages/StudyGroupEdit.tsx
@@ -1,0 +1,3 @@
+export default function StudyGroupEdit() {
+  return <>StudyGroupEdit</>
+}

--- a/src/pages/StudyGroupEdit.tsx
+++ b/src/pages/StudyGroupEdit.tsx
@@ -1,3 +1,30 @@
+import { Button, H2, Text } from '@components'
+import { ArrowLongLeftIcon } from '@heroicons/react/24/outline'
+
 export default function StudyGroupEdit() {
-  return <>StudyGroupEdit</>
+  return (
+    <div className="flex flex-col gap-6 lg:gap-8">
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          className="cursor-pointer rounded-full bg-gray-100 p-3 transition-colors duration-300 hover:bg-gray-200"
+        >
+          <ArrowLongLeftIcon width={16} />
+        </button>
+        <div className="flex flex-col gap-1">
+          <H2>스터디 그룹 수정</H2>
+          <Text className="text-gray-600">
+            스터디 그룹 정보를 수정해주세요.
+          </Text>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-4">
+        <Button variant="outline" className="bg-transparent">
+          취소
+        </Button>
+        <Button>스터디 그룹 만들기</Button>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/StudyGroupEdit.tsx
+++ b/src/pages/StudyGroupEdit.tsx
@@ -1,5 +1,6 @@
-import { Button, H2, Text } from '@components'
 import { ArrowLongLeftIcon } from '@heroicons/react/24/outline'
+
+import { Button, H2, Text } from '@components'
 
 export default function StudyGroupEdit() {
   return (

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export { default as StudyGroupDetail } from '@pages/StudyGroupDetail'
+export { default as StudyGroupEdit } from '@pages/StudyGroupEdit'


### PR DESCRIPTION
## 🚀 PR 요약

- 스터디그룹 수정 페이지 컴포넌트 추가(StudyGroupEdit.tsx)
  - 제목 및 취소, 생성 버튼 ui 추가
- 라우트 설정(/study-group/:groupId/edit)

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

<img width="1516" height="771" alt="image" src="https://github.com/user-attachments/assets/e9708cb4-6c4d-4939-9924-d326bc68bcc1" />

## 🔗 연관된 이슈

> closes #118 
