### PR TITLE
Feature: 스터디 그룹 수정 페이지 내 기간 및 인원 선택 섹션 추가

### DIFF
--- a/src/components/common/form/DateInput.tsx
+++ b/src/components/common/form/DateInput.tsx
@@ -1,7 +1,6 @@
 import { CalendarDaysIcon } from '@heroicons/react/24/outline'
 import { useId, type InputHTMLAttributes, type Ref } from 'react'
 
-
 import { dateInputStyle } from '@components/common/form/form.styles'
 
 interface DateInputProps

--- a/src/components/create-group/MembersSlider.styles.ts
+++ b/src/components/create-group/MembersSlider.styles.ts
@@ -6,6 +6,6 @@ export const SLIDER_TRACK =
 
 export const SLIDER_THUMB =
   // thumb h-5 vs track h-2 → mt = -(20-8)/2 = -6
-  '[&::-webkit-slider-thumb]:bg-primary-500 [&::-webkit-slider-thumb]:mt-[-6px] [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 ' +
-  '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow ' +
+  '[&::-webkit-slider-thumb]:bg-[#007BFF] [&::-webkit-slider-thumb]:mt-[-4px] [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 ' +
+  '[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:shadow ' +
   '[&::-moz-range-thumb]:bg-primary-500 [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:shadow'

--- a/src/components/create-group/MembersSlider.tsx
+++ b/src/components/create-group/MembersSlider.tsx
@@ -10,59 +10,63 @@ import { cn } from '@utils'
 interface MembersInputProps {
   value: number
   onChange: (v: number) => void
-  className: string
+  className?: string
 }
 
-const MembersSlider = ({ value, onChange, className }: MembersInputProps) => (
-  <div className={cn('', className)}>
-    <div className="mb-2 flex items-center justify-between">
-      <label htmlFor="maxMembers" className="text-sm">
-        <Text className="text-gray-700" variant="small">
-          최대 인원 수
-        </Text>
-        <Text className="text-danger-500 ml-0.5" variant="small">
-          *
-        </Text>
-      </label>
-    </div>
+export default function MembersSlider({
+  value,
+  onChange,
+  className,
+}: MembersInputProps) {
+  return (
+    <div className={cn('', className)}>
+      <div className="mb-2 flex items-center justify-between">
+        <label htmlFor="maxMembers" className="text-sm">
+          <Text className="text-gray-700" variant="small">
+            최대 인원 수
+          </Text>
+          <Text className="text-danger-500 ml-0.5" variant="small">
+            *
+          </Text>
+        </label>
+      </div>
 
-    <div className="flex gap-4">
-      <input
-        id="maxMembers"
-        type="range"
-        min={MIN_MEMBERS}
-        max={MAX_MEMBERS}
-        step={1}
-        value={value}
-        onChange={(e) => onChange(e.currentTarget.valueAsNumber)}
-        aria-valuemin={MIN_MEMBERS}
-        aria-valuemax={MAX_MEMBERS}
-        aria-valuenow={value}
-        className={cn(SLIDER_BASE, SLIDER_TRACK, SLIDER_THUMB)}
-      />
-      <div className="flex items-center">
-        <UserGroupIcon width={16} className="text-gray-400" />
-        <Text
-          className="mx-2 w-8 text-center text-lg font-semibold text-gray-900"
-          variant="small"
-        >
-          {value}
+      <div className="flex gap-4">
+        <input
+          id="maxMembers"
+          type="range"
+          min={MIN_MEMBERS}
+          max={MAX_MEMBERS}
+          step={1}
+          value={value}
+          onChange={(e) => onChange(e.currentTarget.valueAsNumber)}
+          aria-valuemin={MIN_MEMBERS}
+          aria-valuemax={MAX_MEMBERS}
+          aria-valuenow={value}
+          className={cn(SLIDER_BASE, SLIDER_TRACK, SLIDER_THUMB)}
+        />
+        <div className="flex items-center">
+          <UserGroupIcon width={16} className="text-gray-400" />
+          <Text
+            className="mx-2 w-8 text-center text-lg font-semibold text-gray-900"
+            variant="small"
+          >
+            {value}
+          </Text>
+          <Text className="text-gray-600" variant="small">
+            명
+          </Text>
+        </div>
+      </div>
+
+      <div className="mt-1 flex justify-between text-[12px] leading-5 text-gray-400">
+        <Text className="text-gray-500" variant="extraSmall">
+          {MIN_MEMBERS}명
         </Text>
-        <Text className="text-gray-600" variant="small">
-          명
+        <Text className="text-gray-500" variant="extraSmall">
+          {MAX_MEMBERS}명
         </Text>
       </div>
     </div>
-
-    <div className="mt-1 flex justify-between text-[12px] leading-5 text-gray-400">
-      <Text className="text-gray-500" variant="extraSmall">
-        {MIN_MEMBERS}명
-      </Text>
-      <Text className="text-gray-500" variant="extraSmall">
-        {MAX_MEMBERS}명
-      </Text>
-    </div>
-  </div>
-)
-
-export default MembersSlider
+  )
+}

--- a/src/components/create-group/MembersSlider.tsx
+++ b/src/components/create-group/MembersSlider.tsx
@@ -1,19 +1,20 @@
-import { MIN_MEMBERS, MAX_MEMBERS , Text } from '@components'
+import { MIN_MEMBERS, MAX_MEMBERS, Text } from '@components'
 import {
   SLIDER_BASE,
   SLIDER_THUMB,
   SLIDER_TRACK,
 } from '@components/create-group/MembersSlider.styles'
+import { UserGroupIcon } from '@heroicons/react/24/outline'
 import { cn } from '@utils'
-
 
 interface MembersInputProps {
   value: number
   onChange: (v: number) => void
+  className: string
 }
 
-const MembersSlider = ({ value, onChange }: MembersInputProps) => (
-  <div className="mt-6">
+const MembersSlider = ({ value, onChange, className }: MembersInputProps) => (
+  <div className={cn('', className)}>
     <div className="mb-2 flex items-center justify-between">
       <label htmlFor="maxMembers" className="text-sm">
         <Text className="text-gray-700" variant="small">
@@ -23,24 +24,35 @@ const MembersSlider = ({ value, onChange }: MembersInputProps) => (
           *
         </Text>
       </label>
-      <Text className="text-gray-600" variant="small">
-        {value} 명
-      </Text>
     </div>
 
-    <input
-      id="maxMembers"
-      type="range"
-      min={MIN_MEMBERS}
-      max={MAX_MEMBERS}
-      step={1}
-      value={value}
-      onChange={(e) => onChange(e.currentTarget.valueAsNumber)}
-      aria-valuemin={MIN_MEMBERS}
-      aria-valuemax={MAX_MEMBERS}
-      aria-valuenow={value}
-      className={cn(SLIDER_BASE, SLIDER_TRACK, SLIDER_THUMB)}
-    />
+    <div className="flex gap-4">
+      <input
+        id="maxMembers"
+        type="range"
+        min={MIN_MEMBERS}
+        max={MAX_MEMBERS}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.valueAsNumber)}
+        aria-valuemin={MIN_MEMBERS}
+        aria-valuemax={MAX_MEMBERS}
+        aria-valuenow={value}
+        className={cn(SLIDER_BASE, SLIDER_TRACK, SLIDER_THUMB)}
+      />
+      <div className="flex items-center">
+        <UserGroupIcon width={16} className="text-gray-400" />
+        <Text
+          className="mx-2 w-8 text-center text-lg font-semibold text-gray-900"
+          variant="small"
+        >
+          {value}
+        </Text>
+        <Text className="text-gray-600" variant="small">
+          명
+        </Text>
+      </div>
+    </div>
 
     <div className="mt-1 flex justify-between text-[12px] leading-5 text-gray-400">
       <Text className="text-gray-500" variant="extraSmall">

--- a/src/components/create-group/MembersSlider.tsx
+++ b/src/components/create-group/MembersSlider.tsx
@@ -1,10 +1,11 @@
+import { UserGroupIcon } from '@heroicons/react/24/outline'
+
 import { MIN_MEMBERS, MAX_MEMBERS, Text } from '@components'
 import {
   SLIDER_BASE,
   SLIDER_THUMB,
   SLIDER_TRACK,
 } from '@components/create-group/MembersSlider.styles'
-import { UserGroupIcon } from '@heroicons/react/24/outline'
 import { cn } from '@utils'
 
 interface MembersInputProps {

--- a/src/components/create-group/index.ts
+++ b/src/components/create-group/index.ts
@@ -4,5 +4,6 @@ export { default as LecturePickerSection } from '@components/create-group/Lectur
 export { default as DateModal } from '@components/create-group/DatePickerModal'
 export { default as MembersSlider } from '@components/create-group/MembersSlider'
 export { default as DateRangeFields } from '@components/create-group/DateRangeFields'
+export { default as DatePickerModal } from '@components/create-group/DatePickerModal'
 export * from '@components/create-group/constants'
 export * from '@components/create-group/types'

--- a/src/components/create-study-group/PeriodMemberSection.tsx
+++ b/src/components/create-study-group/PeriodMemberSection.tsx
@@ -1,4 +1,5 @@
-import { Card, DateInput, MembersSlider } from '@components'
+import useDateModal from '@hooks/useDateModal'
+import { Card, DateInput, MembersSlider, DatePickerModal } from '@components'
 import { useState } from 'react'
 
 const INITIAL_MEMBER_COUNT = 6
@@ -6,21 +7,76 @@ const INITIAL_MEMBER_COUNT = 6
 export default function PeriodMemberSection() {
   const [memberCount, setMemberCount] = useState<number>(INITIAL_MEMBER_COUNT)
 
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+
+  const {
+    openDateKind,
+    tempDate,
+    setTempDate,
+    openStartPicker,
+    openEndPicker,
+    closeDateModal,
+    confirmDateModal,
+    minEndForEndPicker,
+    confirmDisabled,
+    hasRangeError,
+  } = useDateModal({
+    startDate,
+    endDate,
+    setStartDate,
+    setEndDate,
+  })
+
   return (
-    <Card
-      title="스터디 기간 및 인원"
-      titleClassName="text-xl pb-0"
-      cardClassName="p-8 gap-6"
-    >
-      <div className="grid grid-cols-2 grid-rows-2 gap-6">
-        <DateInput label="스터디 시작일" required className="mt-0.5" />
-        <DateInput label="스터디 종료일" required className="mt-0.5" />
-        <MembersSlider
-          className="col-span-2"
-          value={memberCount}
-          onChange={setMemberCount}
-        />
-      </div>
-    </Card>
+    <>
+      <Card
+        title="스터디 기간 및 인원"
+        titleClassName="text-xl pb-0"
+        cardClassName="p-8 gap-6"
+      >
+        <div className="grid grid-cols-2 grid-rows-2 gap-6">
+          <DateInput
+            label="스터디 시작일"
+            required
+            value={startDate}
+            onOpenCalendar={openStartPicker}
+            placeholder="날짜를 선택하세요"
+            aria-label="스터디 시작일"
+          />
+          <DateInput
+            label="스터디 종료일"
+            required
+            value={endDate}
+            onOpenCalendar={openEndPicker}
+            placeholder="날짜를 선택하세요"
+            invalid={hasRangeError}
+            errorText={
+              hasRangeError
+                ? '종료일은 시작일로부터 최소 5일 이후여야 합니다.'
+                : undefined
+            }
+            aria-label="스터디 종료일"
+          />
+          <MembersSlider
+            className="col-span-2"
+            value={memberCount}
+            onChange={setMemberCount}
+          />
+        </div>
+      </Card>
+
+      <DatePickerModal
+        isOpen={!!openDateKind}
+        kind={openDateKind}
+        tempDate={tempDate}
+        setTempDate={setTempDate}
+        close={closeDateModal}
+        confirm={confirmDateModal}
+        confirmDisabled={confirmDisabled}
+        minEndForEndPicker={minEndForEndPicker}
+        endDate={endDate}
+      />
+    </>
   )
 }

--- a/src/components/create-study-group/PeriodMemberSection.tsx
+++ b/src/components/create-study-group/PeriodMemberSection.tsx
@@ -1,0 +1,26 @@
+import { Card, DateInput, MembersSlider } from '@components'
+import { useState } from 'react'
+
+const INITIAL_MEMBER_COUNT = 6
+
+export default function PeriodMemberSection() {
+  const [memberCount, setMemberCount] = useState<number>(INITIAL_MEMBER_COUNT)
+
+  return (
+    <Card
+      title="스터디 기간 및 인원"
+      titleClassName="text-xl pb-0"
+      cardClassName="p-8 gap-6"
+    >
+      <div className="grid grid-cols-2 grid-rows-2 gap-6">
+        <DateInput label="스터디 시작일" required className="mt-0.5" />
+        <DateInput label="스터디 종료일" required className="mt-0.5" />
+        <MembersSlider
+          className="col-span-2"
+          value={memberCount}
+          onChange={setMemberCount}
+        />
+      </div>
+    </Card>
+  )
+}

--- a/src/components/create-study-group/PeriodMemberSection.tsx
+++ b/src/components/create-study-group/PeriodMemberSection.tsx
@@ -1,6 +1,7 @@
-import useDateModal from '@hooks/useDateModal'
-import { Card, DateInput, MembersSlider, DatePickerModal } from '@components'
 import { useState } from 'react'
+
+import { Card, DateInput, MembersSlider, DatePickerModal } from '@components'
+import useDateModal from '@hooks/useDateModal'
 
 const INITIAL_MEMBER_COUNT = 6
 

--- a/src/components/create-study-group/index.ts
+++ b/src/components/create-study-group/index.ts
@@ -1,1 +1,2 @@
 export { default as PrimaryInfoSection } from '@components/create-study-group/PrimaryInfoSection'
+export { default as PeriodMemberSection } from '@components/create-study-group/PeriodMemberSection'

--- a/src/pages/StudyGroupEdit.tsx
+++ b/src/pages/StudyGroupEdit.tsx
@@ -1,10 +1,16 @@
 import { ArrowLongLeftIcon } from '@heroicons/react/24/outline'
 
-import { Button, H2, Text, PrimaryInfoSection } from '@components'
+import {
+  Button,
+  H2,
+  Text,
+  PrimaryInfoSection,
+  PeriodMemberSection,
+} from '@components'
 
 export default function StudyGroupEdit() {
   return (
-    <div className="flex flex-col gap-6 lg:gap-8">
+    <form className="flex flex-col gap-6 lg:gap-8">
       <div className="flex items-center gap-4">
         <button
           type="button"
@@ -21,13 +27,14 @@ export default function StudyGroupEdit() {
       </div>
 
       <PrimaryInfoSection />
+      <PeriodMemberSection />
 
       <div className="flex justify-end gap-4">
         <Button variant="outline" className="bg-transparent">
           취소
         </Button>
-        <Button>스터디 그룹 만들기</Button>
+        <Button type="submit">스터디 그룹 만들기</Button>
       </div>
-    </div>
+    </form>
   )
 }


### PR DESCRIPTION
## 🚀 PR 요약

스터디 그룹 수정 페이지 내 기간 및 인원 선택 섹션 추가(PeriodMemberSection.tsx)

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가
- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

MembersSlider 컴포넌트를 피그마 디자인과 동일하도록 ui 수정하였습니다.

<img width="900" height="901" alt="image" src="https://github.com/user-attachments/assets/5d4bea98-6551-462b-a9ba-8595cc8a914d" />

<img width="900" height="903" alt="image" src="https://github.com/user-attachments/assets/5cd24cac-4f5b-4122-b764-d1328cca8c07" />


## 🔗 연관된 이슈

> closes #120 
