### PR TITLE
Feature: 스터디 그룹 상세 조회 api 연동 (msw)

### DIFF
--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -1,19 +1,21 @@
 import { API_PATHS } from '@constants'
 import { axiosInstance } from '@lib'
 
+import type { CreateStudyGroupResponse, StudyGroupDetailResponse } from '@api'
+
 export const studyApi = {
   getStudyGroupList: async () => {
     const response = await axiosInstance.get(API_PATHS.STUDY_GROUP.LIST)
     return response.data
   },
   getStudyGroupDetail: async (groupUuid: string) => {
-    const response = await axiosInstance.get(
+    const response = await axiosInstance.get<StudyGroupDetailResponse>(
       API_PATHS.STUDY_GROUP.DETAIL(groupUuid)
     )
     return response.data
   },
   createStudyGroup: async (data: FormData) => {
-    const response = await axiosInstance.post(
+    const response = await axiosInstance.post<CreateStudyGroupResponse>(
       API_PATHS.STUDY_GROUP.CREATE,
       data
     )

--- a/src/api/types/group.ts
+++ b/src/api/types/group.ts
@@ -1,3 +1,5 @@
+import type { StudyGroupStatus } from '@models'
+
 export interface CreateStudyGroupRequest {
   name: string
   introduction?: string | null
@@ -38,7 +40,7 @@ export interface StudyGroupDetailResponse {
   imgUrl: string
   startAt: string
   endAt: string
-  status: string
+  status: StudyGroupStatus
   lectures: {
     lectureId: number
     lectureTitle: string

--- a/src/api/types/group.ts
+++ b/src/api/types/group.ts
@@ -20,3 +20,30 @@ export interface CreateStudyGroupResponse {
   lectures: number[]
   createdAt: string
 }
+
+export interface StudyGroupDetailResponse {
+  uuid: string
+  name: string
+  current_headcount: number
+  maxHeadcount: number
+  leader: {
+    uuid: string
+    nickname: string
+  }
+  members: {
+    uuid: string
+    nickname: string
+    isLeader: boolean
+  }[]
+  imgUrl: string
+  startAt: string
+  endAt: string
+  status: string
+  lectures: {
+    lectureId: number
+    lectureTitle: string
+    instructor: string
+    thumbnailImg: string
+    urlLink: string
+  }[]
+}

--- a/src/components/common/study-badge/StudyBadge.tsx
+++ b/src/components/common/study-badge/StudyBadge.tsx
@@ -14,10 +14,6 @@ interface StudyBadgeProps
   children?: ReactNode
 }
 
-interface setLabelTextProps {
-  variant?: string | null
-}
-
 export default function StudyBadge({
   variant,
   size,
@@ -29,22 +25,14 @@ export default function StudyBadge({
 }: StudyBadgeProps) {
   const memberCountText = `${member ?? '--'}/${maxMember ?? '--'}명`
 
-  const setLabelText = ({ variant = 'primary' }: setLabelTextProps): string => {
-    switch (variant) {
-      case 'primary':
-        return memberCountText
-      case 'inProgress':
-        return '진행중'
-      case 'ended':
-        return '종료됨'
-      case 'leader':
-        return '리더'
-      default:
-        return ''
+  const getLabel = () => {
+    if (variant === 'primary') {
+      return memberCountText
     }
+    return variant
   }
 
-  const label = setLabelText({ variant: variant })
+  const label = getLabel()
 
   return (
     <div

--- a/src/components/common/study-badge/StudyBadge.tsx
+++ b/src/components/common/study-badge/StudyBadge.tsx
@@ -1,4 +1,3 @@
-import type React from 'react'
 import type { ReactNode } from 'react'
 
 import { type VariantProps } from 'class-variance-authority'

--- a/src/components/common/study-badge/StudyBadge.tsx
+++ b/src/components/common/study-badge/StudyBadge.tsx
@@ -27,7 +27,7 @@ export default function StudyBadge({
   const getLabel = () => {
     if (variant === 'primary') {
       return memberCountText
-    }
+    } else if (variant === 'leader') return '리더'
     return variant
   }
 
@@ -38,7 +38,7 @@ export default function StudyBadge({
       className={cn(studyBadgeVariants({ variant, size }), className)}
       {...props}
     >
-      {children}&nbsp;
+      {children}
       {label}
     </div>
   )

--- a/src/components/common/study-badge/studyBadgeVariants.ts
+++ b/src/components/common/study-badge/studyBadgeVariants.ts
@@ -4,8 +4,9 @@ export const studyBadgeVariants = cva(['py-1', 'rounded-full', 'font-medium'], {
   variants: {
     variant: {
       primary: ['text-gray-900', 'bg-white'],
-      inProgress: ['text-white', 'bg-success-500'],
-      ended: ['text-white', 'bg-gray-500'],
+      진행중: ['text-white', 'bg-success-500'],
+      대기중: ['text-gray-900', 'bg-success-100'],
+      종료됨: ['text-white', 'bg-gray-500'],
       leader: ['text-white', 'bg-primary-500'],
     },
     size: {

--- a/src/components/study-group-detail/StudyGroupHeader.tsx
+++ b/src/components/study-group-detail/StudyGroupHeader.tsx
@@ -20,6 +20,7 @@ interface StudyGroupHeaderProps
     | 'currentHeadcount'
     | 'maxHeadcount'
     | 'startAt'
+    | 'status'
     | 'endAt'
   > {
   currentUserRole?: 'member' | 'leader' | 'guest'
@@ -33,6 +34,7 @@ export default function StudyGroupHeader({
   maxHeadcount,
   startAt,
   endAt,
+  status,
   currentUserRole,
   isMember,
 }: StudyGroupHeaderProps) {
@@ -65,7 +67,7 @@ export default function StudyGroupHeader({
               {formattedStartDate} ~ {formattedLastDate}
             </Text>
           </div>
-          <StudyBadge variant="inProgress" />
+          <StudyBadge variant={status} />
         </div>
       </div>
 

--- a/src/components/study-group-detail/StudyGroupInfo.tsx
+++ b/src/components/study-group-detail/StudyGroupInfo.tsx
@@ -8,9 +8,10 @@ export default function StudyGroupInfo({
   maxHeadcount,
   startAt,
   endAt,
+  status,
 }: Pick<
   StudyGroupDetail,
-  'currentHeadcount' | 'maxHeadcount' | 'startAt' | 'endAt'
+  'currentHeadcount' | 'maxHeadcount' | 'startAt' | 'endAt' | 'status'
 >) {
   const formattedStartDate = formatDate(new Date(startAt))
   const formattedLastDate = formatDate(new Date(endAt))
@@ -18,7 +19,7 @@ export default function StudyGroupInfo({
   const STUDY_GROUP_INFO = [
     {
       title: '인원',
-      content: `${currentHeadcount ?? 8}/${maxHeadcount ?? 10}명`,
+      content: `${currentHeadcount}/${maxHeadcount}명`,
     },
     {
       title: '시작일',
@@ -30,7 +31,7 @@ export default function StudyGroupInfo({
     },
     {
       title: '상태',
-      content: <StudyBadge variant="inProgress" />,
+      content: <StudyBadge variant={status} />,
     },
   ]
 

--- a/src/components/study-group-detail/StudyGroupLogList.tsx
+++ b/src/components/study-group-detail/StudyGroupLogList.tsx
@@ -1,6 +1,6 @@
 import { PaperClipIcon, PencilIcon } from '@heroicons/react/24/outline'
 
-import { Avatar, Button, Card, Text } from '@components'
+import { Avatar, Button, Card, EmptyState, Text } from '@components'
 import { formatDate } from '@utils'
 
 import type { StudyGroupMemberList, StudyLogListItem } from '@models'
@@ -20,37 +20,51 @@ export default function StudyGroupLogList({
       titleClassName="text-xl mt-1.5 mb-2"
       cardClassName="flex gap-4"
     >
-      <Button className="absolute right-6 px-4 py-2" size="large">
-        <PencilIcon width={16} />
-        작성하기
-      </Button>
+      {studyLog.length > 0 && (
+        <Button className="absolute right-6 px-4 py-2" size="large">
+          <PencilIcon width={16} />
+          작성하기
+        </Button>
+      )}
 
-      {studyLog?.map((log) => {
-        const author = member.find((el) => el.nickname === log.author.nickname)
+      {studyLog.length === 0 ? (
+        <EmptyState
+          title="아직 스터디 기록이 없습니다"
+          description="첫 번째 기록을 추가해보세요"
+          createLabel="작성하기"
+        />
+      ) : (
+        <>
+          {studyLog.map((log) => {
+            const author = member.find(
+              (el) => el.nickname === log.author.nickname
+            )
 
-        return (
-          <Card key={log.id} title={log.title} cardClassName="p-4">
-            <Text className="absolute right-4 mb-3 text-sm text-gray-500">
-              {formatDate(new Date(log.createdAt))}
-            </Text>
-
-            <div className="flex gap-3">
-              <Avatar alt={author?.nickname || ''} />
-              <div>
-                <Text className="text-sm font-medium text-gray-700">
-                  {author?.nickname}
+            return (
+              <Card key={log.id} title={log.title} cardClassName="p-4">
+                <Text className="absolute right-4 mb-3 text-sm text-gray-500">
+                  {formatDate(new Date(log.createdAt))}
                 </Text>
-                <div className="flex gap-1 text-gray-500">
-                  <PaperClipIcon width={12} />
-                  {/* <Text className="text-xs font-medium">
+
+                <div className="flex gap-3">
+                  <Avatar alt={author?.nickname || ''} />
+                  <div>
+                    <Text className="text-sm font-medium text-gray-700">
+                      {author?.nickname}
+                    </Text>
+                    <div className="flex gap-1 text-gray-500">
+                      <PaperClipIcon width={12} />
+                      {/* <Text className="text-xs font-medium">
                     첨부파일 {log.attachments?.length} 개
                   </Text> */}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          </Card>
-        )
-      })}
+              </Card>
+            )
+          })}
+        </>
+      )}
     </Card>
   )
 }

--- a/src/components/study-group-detail/StudyGroupLogList.tsx
+++ b/src/components/study-group-detail/StudyGroupLogList.tsx
@@ -3,8 +3,9 @@ import { PaperClipIcon, PencilIcon } from '@heroicons/react/24/outline'
 import { Avatar, Button, Card, EmptyState, Text } from '@components'
 import { formatDate } from '@utils'
 
-import type { StudyGroupMemberList, StudyLogListItem } from '@models'
 import { usePageNav } from '@/hooks'
+
+import type { StudyGroupMemberList, StudyLogListItem } from '@models'
 
 interface StudyGroupLogListProps {
   member: StudyGroupMemberList[]

--- a/src/components/study-group-detail/StudyGroupLogList.tsx
+++ b/src/components/study-group-detail/StudyGroupLogList.tsx
@@ -4,6 +4,7 @@ import { Avatar, Button, Card, EmptyState, Text } from '@components'
 import { formatDate } from '@utils'
 
 import type { StudyGroupMemberList, StudyLogListItem } from '@models'
+import { usePageNav } from '@/hooks'
 
 interface StudyGroupLogListProps {
   member: StudyGroupMemberList[]
@@ -14,6 +15,8 @@ export default function StudyGroupLogList({
   member,
   studyLog,
 }: StudyGroupLogListProps) {
+  const { navigateToLogCreate } = usePageNav()
+
   return (
     <Card
       title="스터디 기록"
@@ -21,7 +24,11 @@ export default function StudyGroupLogList({
       cardClassName="flex gap-4"
     >
       {studyLog.length > 0 && (
-        <Button className="absolute right-6 px-4 py-2" size="large">
+        <Button
+          className="absolute right-6 px-4 py-2"
+          size="large"
+          onClick={navigateToLogCreate}
+        >
           <PencilIcon width={16} />
           작성하기
         </Button>
@@ -32,6 +39,7 @@ export default function StudyGroupLogList({
           title="아직 스터디 기록이 없습니다"
           description="첫 번째 기록을 추가해보세요"
           createLabel="작성하기"
+          onCreate={navigateToLogCreate}
         />
       ) : (
         <>

--- a/src/components/study-group/StudyGroupCardOverlay.tsx
+++ b/src/components/study-group/StudyGroupCardOverlay.tsx
@@ -2,10 +2,10 @@ import { useLocation } from 'react-router'
 
 import { StudyBadge } from '@components'
 
-import { STATUS_TO_VARIANT } from '@/constants'
+import type { StudyGroupStatus } from '@models'
 
 interface StudyCardOverlayProps {
-  status: string
+  status: StudyGroupStatus
   isLeader: boolean
   maxHeadcount: number
   currentHeadcount: number
@@ -20,11 +20,6 @@ export default function StudyGroupCardOverlay({
   const location = useLocation()
   const showBadges = location.pathname === '/study-group'
 
-  // status 문자열에 해당하는 variant 값을 찾음
-  const statusVariant = status
-    ? STATUS_TO_VARIANT[status as keyof typeof STATUS_TO_VARIANT]
-    : undefined
-
   if (!showBadges) {
     return null
   }
@@ -32,7 +27,7 @@ export default function StudyGroupCardOverlay({
   return (
     <div className="absolute top-0 z-10 flex h-full w-full flex-col justify-between p-3">
       <div className="flex justify-between">
-        {statusVariant && <StudyBadge variant={statusVariant} size="small" />}
+        {status && <StudyBadge variant={status} size="small" />}
         {isLeader && <StudyBadge variant="leader" size="small" />}
       </div>
       <StudyBadge

--- a/src/components/study-group/StudyGroupEmptySearchResult.tsx
+++ b/src/components/study-group/StudyGroupEmptySearchResult.tsx
@@ -1,10 +1,11 @@
 import { BaseEmptyState, EmptyState } from '@components'
 
-import { CompletedIcon, InProgressIcon } from '@/assets'
-import { usePageNav } from '@/hooks'
+import { CompletedIcon, InProgressIcon } from '@assets'
+import { usePageNav } from '@hooks'
+import type { StudyGroupStatus } from '@models'
 
 interface StudyGroupEmptySearchResultProps {
-  variant: 'inProgress' | 'ended'
+  variant: StudyGroupStatus
 }
 
 export default function StudyGroupEmptySearchResult({
@@ -12,7 +13,7 @@ export default function StudyGroupEmptySearchResult({
 }: StudyGroupEmptySearchResultProps) {
   const { navigateToCreateNewStudy } = usePageNav()
 
-  if (variant === 'inProgress') {
+  if (variant === '진행중') {
     return (
       <EmptyState
         title="검색된 진행중인 스터디가 없습니다"

--- a/src/components/study-group/StudyGroupSection.tsx
+++ b/src/components/study-group/StudyGroupSection.tsx
@@ -1,11 +1,16 @@
-import { SectionHeader, StudyBadge, StudyGroupCardList , StudyGroupEmptySearchResult } from '@components'
+import {
+  SectionHeader,
+  StudyBadge,
+  StudyGroupCardList,
+  StudyGroupEmptySearchResult,
+} from '@components'
 
-import type { StudyGroupList } from '@/types'
+import type { StudyGroupList, StudyGroupStatus } from '@models'
 
 interface StudyGroupSectionProps {
   title: string
   subtitle: string
-  badgeVariant: 'inProgress' | 'ended'
+  badgeVariant: StudyGroupStatus
   badgeClassName: string
   groups: StudyGroupList[]
 }
@@ -21,7 +26,7 @@ export default function StudyGroupSection({
     <section className="flex flex-col gap-6">
       <SectionHeader title={title} subtitle={subtitle} titleVariant="2xl">
         <StudyBadge variant={badgeVariant} className={badgeClassName}>
-          {groups.length}개
+          {groups.length}개&nbsp;
         </StudyBadge>
       </SectionHeader>
       {groups.length > 0 ? (

--- a/src/constants/studyGroup.ts
+++ b/src/constants/studyGroup.ts
@@ -10,9 +10,3 @@ export const STUDY_GROUP_STATUS = {
   COMPLETED: '종료됨',
   IN_PROGRESS: '진행중',
 } as const
-
-// status 문자열을 variant 값으로 변환하기 위한 객체
-export const STATUS_TO_VARIANT = {
-  [STUDY_GROUP_STATUS.COMPLETED]: 'ended',
-  [STUDY_GROUP_STATUS.IN_PROGRESS]: 'inProgress',
-} as const

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,2 +1,3 @@
 export * from '@hooks/queries/useStudyGroupMutations'
+export * from '@hooks/queries/useStudyGroupDetail'
 export * from '@hooks/queries/queryKey'

--- a/src/hooks/queries/queryKey.ts
+++ b/src/hooks/queries/queryKey.ts
@@ -1,4 +1,5 @@
 export const studyQueryKey = {
-  base: ['study'],
-  getList: ['study', 'list'],
+  base: ['studies'],
+  create: () => [...studyQueryKey.base, 'create'],
+  detail: (groupUuid: string) => [...studyQueryKey.base, 'detail', groupUuid],
 }

--- a/src/hooks/queries/useStudyGroupDetail.ts
+++ b/src/hooks/queries/useStudyGroupDetail.ts
@@ -4,7 +4,7 @@ import { studyQueryKey } from '@hooks'
 
 export const useStudyGroupDetail = (groupUuid: string) => {
   return useQuery({
-    queryKey: [...studyQueryKey.base, groupUuid],
+    queryKey: studyQueryKey.detail(groupUuid),
     queryFn: () => studyApi.getStudyGroupDetail(groupUuid),
     enabled: !!groupUuid,
   })

--- a/src/hooks/queries/useStudyGroupDetail.ts
+++ b/src/hooks/queries/useStudyGroupDetail.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { studyApi } from '@api'
+import { studyQueryKey } from '@hooks'
+
+export const useStudyGroupDetail = (groupUuid: string) => {
+  return useQuery({
+    queryKey: [...studyQueryKey.base, groupUuid],
+    queryFn: () => studyApi.getStudyGroupDetail(groupUuid),
+    enabled: !!groupUuid,
+  })
+}

--- a/src/hooks/queries/useStudyGroupDetail.ts
+++ b/src/hooks/queries/useStudyGroupDetail.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+
 import { studyApi } from '@api'
 import { studyQueryKey } from '@hooks'
 

--- a/src/hooks/queries/useStudyGroupMutations.ts
+++ b/src/hooks/queries/useStudyGroupMutations.ts
@@ -11,10 +11,10 @@ export const useStudyGroupMutations = () => {
   return useMutation<AxiosResponse<CreateStudyGroupResponse>, Error, FormData>({
     mutationFn: (data) => studyApi.createStudyGroup(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: studyQueryKey.getList })
+      queryClient.invalidateQueries({ queryKey: studyQueryKey.create() })
     },
     onError: () => {
-      queryClient.cancelQueries({ queryKey: studyQueryKey.getList })
+      queryClient.cancelQueries({ queryKey: studyQueryKey.create() })
     },
   })
 }

--- a/src/hooks/usePageNav.ts
+++ b/src/hooks/usePageNav.ts
@@ -16,6 +16,10 @@ export const usePageNav = () => {
     navigate(`/study-group/${params.groupId}/edit`)
   }
 
+  const navigateToLogCreate = () => {
+    navigate(`/study-group/${params.groupId}/records/create`)
+  }
+
   const navigateToLogEdit = () => {
     navigate(`/study-group/${params.groupId}/records/${params.recordId}/edit`)
   }
@@ -33,6 +37,7 @@ export const usePageNav = () => {
     handleGoBack,
     navigateToGroupList,
     navigateToGroupEdit,
+    navigateToLogCreate,
     navigateToLogEdit,
     navigateToCreateNewStudy,
     navigateToGroupDetail,

--- a/src/mocks/handlers/studyGroupHandlers.ts
+++ b/src/mocks/handlers/studyGroupHandlers.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
 
 import { API_BASE_URL, API_PATHS } from '@constants'
+import { studyGroup } from '@mocks/datas/studyGroupDetail'
 
 export const studyGroupHandlers = [
   // 스터디 그룹 생성
@@ -35,6 +36,43 @@ export const studyGroupHandlers = [
         },
         { status: 201 }
       )
+    }
+  ),
+
+  // 스터디 그룹 상세 조회
+  http.get(
+    `${API_BASE_URL}${API_PATHS.STUDY_GROUP.DETAIL(':group_uuid')}`,
+    ({ params }) => {
+      const { group_uuid } = params
+
+      const mockResponse = {
+        uuid: group_uuid,
+        name: studyGroup.name,
+        current_headcount: studyGroup.currentHeadcount,
+        max_headcount: studyGroup.maxHeadcount,
+        leader: {
+          uuid: studyGroup.leader.uuid,
+          nickname: studyGroup.leader.nickname,
+        },
+        members: studyGroup.members.map((member) => ({
+          uuid: member.uuid,
+          nickname: member.nickname,
+          is_leader: member.isLeader,
+        })),
+        img_url: studyGroup.imgUrl,
+        start_at: studyGroup.startAt,
+        end_at: studyGroup.endAt,
+        status: studyGroup.status,
+        lectures: studyGroup.lectures.map((lecture) => ({
+          lecture_id: lecture.id,
+          lecture_title: lecture.lectureTitle,
+          instructor: lecture.instructor,
+          thumnail_img: lecture.thumbnailImg,
+          url_link: lecture.urlLink,
+        })),
+      }
+
+      return HttpResponse.json(mockResponse, { status: 200 })
     }
   ),
 ]

--- a/src/pages/StudyGroup.tsx
+++ b/src/pages/StudyGroup.tsx
@@ -30,14 +30,14 @@ export default function StudyGroup() {
         <StudyGroupSection
           title="진행중인 스터디"
           subtitle="현재 활발히 진행되고 있는 스터디 그룹들"
-          badgeVariant="inProgress"
+          badgeVariant="진행중"
           badgeClassName="bg-green-100 text-green-800"
           groups={inProgressGroups}
         />
         <StudyGroupSection
           title="완료된 스터디"
           subtitle="성공적으로 마무리된 스터디 그룹들"
-          badgeVariant="ended"
+          badgeVariant="종료됨"
           badgeClassName="bg-gray-100 text-gray-800"
           groups={completedGroups}
         />

--- a/src/pages/StudyGroupDetail.tsx
+++ b/src/pages/StudyGroupDetail.tsx
@@ -30,6 +30,7 @@ export default function StudyGroupDetail() {
     max_headcount: maxHeadcount,
     start_at: startAt,
     end_at: endAt,
+    status,
     members,
     lectures,
   } = studyGroupData
@@ -45,6 +46,7 @@ export default function StudyGroupDetail() {
         maxHeadcount={maxHeadcount}
         startAt={startAt}
         endAt={endAt}
+        status={status}
       />
       <div className="mt-6 flex flex-col gap-6 lg:mt-8 lg:grid lg:grid-cols-3">
         <div className="col-span-2 flex flex-col gap-6 lg:gap-8">
@@ -57,6 +59,7 @@ export default function StudyGroupDetail() {
             maxHeadcount={maxHeadcount}
             startAt={startAt}
             endAt={endAt}
+            status={status}
           />
           {lectures && <StudyGroupLecture lectures={lectures} />}
           <StudyGroupMember members={members} />

--- a/src/pages/StudyGroupDetail.tsx
+++ b/src/pages/StudyGroupDetail.tsx
@@ -1,4 +1,6 @@
+import { useParams } from 'react-router-dom'
 import {
+  LoadingState,
   StudyGroupHeader,
   StudyGroupInfo,
   StudyGroupLecture,
@@ -6,41 +8,58 @@ import {
   StudyGroupMember,
   StudyGroupSchedule,
 } from '@components'
-import {
-  studyGroup,
-  studyGroupLog,
-  studyGroupSchedule,
-} from '@mocks/datas/studyGroupDetail'
+import { useStudyGroupDetail } from '@hooks'
 
 export default function StudyGroupDetail() {
+  const { groupId } = useParams<{ groupId: string }>()
+
+  const { data: studyGroupData, isLoading } = useStudyGroupDetail(groupId || '')
+
+  if (isLoading) {
+    return <LoadingState />
+  }
+
+  if (!studyGroupData) {
+    // TODO: 404 컴포넌트
+    return <div>스터디 그룹을 찾을 수 없습니다.</div>
+  }
+
+  const {
+    name,
+    current_headcount: currentHeadcount,
+    max_headcount: maxHeadcount,
+    start_at: startAt,
+    end_at: endAt,
+    members,
+    lectures,
+  } = studyGroupData
+
+  const studyGroupLog: any[] = []
+  const studyGroupSchedule: any[] = []
+
   return (
     <>
       <StudyGroupHeader
-        name={studyGroup.name}
-        currentHeadcount={studyGroup.currentHeadcount}
-        maxHeadcount={studyGroup.maxHeadcount}
-        startAt={studyGroup.startAt}
-        endAt={studyGroup.endAt}
+        name={name}
+        currentHeadcount={currentHeadcount}
+        maxHeadcount={maxHeadcount}
+        startAt={startAt}
+        endAt={endAt}
       />
       <div className="mt-6 flex flex-col gap-6 lg:mt-8 lg:grid lg:grid-cols-3">
         <div className="col-span-2 flex flex-col gap-6 lg:gap-8">
           <StudyGroupSchedule schedule={studyGroupSchedule} />
-          <StudyGroupLogList
-            member={studyGroup.members}
-            studyLog={studyGroupLog}
-          />
+          <StudyGroupLogList member={members} studyLog={studyGroupLog} />
         </div>
         <div className="flex flex-col gap-6">
           <StudyGroupInfo
-            currentHeadcount={studyGroup.currentHeadcount}
-            maxHeadcount={studyGroup.maxHeadcount}
-            startAt={studyGroup.startAt}
-            endAt={studyGroup.endAt}
+            currentHeadcount={currentHeadcount}
+            maxHeadcount={maxHeadcount}
+            startAt={startAt}
+            endAt={endAt}
           />
-          {studyGroup.lectures && (
-            <StudyGroupLecture lectures={studyGroup.lectures} />
-          )}
-          <StudyGroupMember members={studyGroup.members} />
+          {lectures && <StudyGroupLecture lectures={lectures} />}
+          <StudyGroupMember members={members} />
         </div>
       </div>
     </>

--- a/src/pages/StudyGroupDetail.tsx
+++ b/src/pages/StudyGroupDetail.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom'
+
 import {
   LoadingState,
   StudyGroupHeader,
@@ -35,9 +36,6 @@ export default function StudyGroupDetail() {
     lectures,
   } = studyGroupData
 
-  const studyGroupLog: any[] = []
-  const studyGroupSchedule: any[] = []
-
   return (
     <>
       <StudyGroupHeader
@@ -50,8 +48,8 @@ export default function StudyGroupDetail() {
       />
       <div className="mt-6 flex flex-col gap-6 lg:mt-8 lg:grid lg:grid-cols-3">
         <div className="col-span-2 flex flex-col gap-6 lg:gap-8">
-          <StudyGroupSchedule schedule={studyGroupSchedule} />
-          <StudyGroupLogList member={members} studyLog={studyGroupLog} />
+          <StudyGroupSchedule schedule={[]} />
+          <StudyGroupLogList member={members} studyLog={[]} />
         </div>
         <div className="flex flex-col gap-6">
           <StudyGroupInfo


### PR DESCRIPTION
## 🚀 PR 요약

- 스터디그룹 상세 조회 msw 핸들러 추가
- 상세 조회 쿼리 훅 추가
- 로딩 상태 추가
- 스터디 기록 없을 때 상태 추가
- 스터디 기록 작성하기 버튼 클릭 시 기록 작성 페이지로 이동
- 스터디 배지 컴포넌트 수정
  - variant 값 변경
  - 공백 제거(필요 시 children으로 같이 전달) 

## ✏️ 변경 유형

- [x] feat: 새로운 기능 추가

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

<img width="1909" height="948" alt="image" src="https://github.com/user-attachments/assets/b3948ed3-4bc9-45f3-b8ab-cab711482fbf" />


### 로딩 중
<img width="1167" height="543" alt="스크린샷 2025-09-26 034345" src="https://github.com/user-attachments/assets/0592f01b-5830-4336-8fb1-f19e345db136" />

### 스터디 기록 없음
<img width="644" height="379" alt="image" src="https://github.com/user-attachments/assets/dfdf533a-a70a-4dc7-9ef9-47f627300a08" />



## 🔗 연관된 이슈

> closes #212 