### PR TITLE
Style: 로그 디테일 페이지 반응형 디자인 수정

### DIFF
--- a/src/api/types/auth.ts
+++ b/src/api/types/auth.ts
@@ -1,6 +1,6 @@
 export type LoginResponse = {
-  access: string
-  refresh: string
+  accessToken: string
+  refreshToken: string
 }
 
 export type LoginRequest = {

--- a/src/components/study-log-detail/LogDetailAISummary.tsx
+++ b/src/components/study-log-detail/LogDetailAISummary.tsx
@@ -27,7 +27,7 @@ export default function LogDetailAISummary({
     return null
   }
   return (
-    <section className="flex flex-col border border-b-0 border-gray-200 p-6">
+    <section className="flex flex-col border border-b-0 border-gray-200 p-4 sm:p-6">
       <div className="flex items-center justify-between pb-4">
         <div className="flex items-center justify-center gap-2">
           <AIIcon />
@@ -40,7 +40,7 @@ export default function LogDetailAISummary({
           onClick={handleToggleSummary}
         >
           <Icon className="h-4 w-4" />
-          <Text variant="small" className="text-gray-600">
+          <Text variant="small" className="flex wrap-normal text-gray-600">
             {toggleConfig.label}
           </Text>
         </button>

--- a/src/components/study-log-detail/LogDetailAttachments.tsx
+++ b/src/components/study-log-detail/LogDetailAttachments.tsx
@@ -20,23 +20,19 @@ export default function LogDetailAttachments({
         </Text>
       </div>
       {attachments && attachments.length > 0 && (
-        <ul className="grid grid-cols-1 justify-between gap-2 sm:grid-cols-2 sm:gap-4">
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-4">
           {attachments.map((file) => (
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={file.fileUrl}
-              download={file.fileName}
-              className="flex w-full flex-col items-center gap-1 rounded-lg border border-gray-200 p-3 sm:flex-row sm:gap-3"
-            >
-              <li
-                key={file.id}
-                className="flex w-full flex-col items-center justify-between gap-2 sm:flex-row sm:gap-4"
+            <li key={file.id}>
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href={file.fileUrl}
+                download={file.fileName}
+                className="flex w-full flex-col items-center gap-3 rounded-lg border border-gray-200 p-3 sm:flex-row"
               >
                 {isImageFile(file.fileName) ? <ImageIcon /> : <ZipIcon />}
-
-                <div className="text-center sm:w-full sm:text-start">
-                  <Text className="flex text-xs font-medium wrap-break-word sm:text-sm">
+                <div className="flex w-full flex-col">
+                  <Text variant="small" className="font-medium wrap-normal">
                     {file.fileName}
                   </Text>
                   <Text
@@ -47,8 +43,8 @@ export default function LogDetailAttachments({
                   </Text>
                 </div>
                 <DownloadIcon />
-              </li>
-            </a>
+              </a>
+            </li>
           ))}
         </ul>
       )}

--- a/src/components/study-log-detail/LogDetailAttachments.tsx
+++ b/src/components/study-log-detail/LogDetailAttachments.tsx
@@ -12,7 +12,7 @@ export default function LogDetailAttachments({
   attachments,
 }: LogDetailAttachmentsProps) {
   return (
-    <section className="flex flex-col gap-4 rounded-b-xl border border-t-0 border-gray-200 p-6">
+    <section className="flex flex-col gap-4 rounded-b-xl border border-t-0 border-gray-200 p-4 sm:p-6">
       <div className="flex w-full items-center gap-2">
         <AttachmentIcon />
         <Text variant="large" className="font-semibold">
@@ -20,32 +20,35 @@ export default function LogDetailAttachments({
         </Text>
       </div>
       {attachments && attachments.length > 0 && (
-        <ul className="grid grid-cols-2 justify-between gap-4">
+        <ul className="grid grid-cols-1 justify-between gap-2 sm:grid-cols-2 sm:gap-4">
           {attachments.map((file) => (
-            <li
-              key={file.id}
-              className="flex w-full items-center gap-3 rounded-lg border border-gray-200 p-3"
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={file.fileUrl}
+              download={file.fileName}
+              className="flex w-full flex-col items-center gap-1 rounded-lg border border-gray-200 p-3 sm:flex-row sm:gap-3"
             >
-              {isImageFile(file.fileName) ? <ImageIcon /> : <ZipIcon />}
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={file.fileUrl}
-                download={file.fileName}
-                className="flex w-full flex-col"
+              <li
+                key={file.id}
+                className="flex w-full flex-col items-center justify-between gap-2 sm:flex-row sm:gap-4"
               >
-                <Text variant="small" className="font-medium">
-                  {file.fileName}
-                </Text>
-                <Text
-                  variant="extraSmall"
-                  className="font-normal text-gray-500"
-                >
-                  다운로드 가능
-                </Text>
-              </a>
-              <DownloadIcon />
-            </li>
+                {isImageFile(file.fileName) ? <ImageIcon /> : <ZipIcon />}
+
+                <div className="text-center sm:w-full sm:text-start">
+                  <Text className="flex text-xs font-medium wrap-break-word sm:text-sm">
+                    {file.fileName}
+                  </Text>
+                  <Text
+                    variant="extraSmall"
+                    className="font-normal text-gray-500"
+                  >
+                    다운로드 가능
+                  </Text>
+                </div>
+                <DownloadIcon />
+              </li>
+            </a>
           ))}
         </ul>
       )}

--- a/src/components/study-log-detail/LogDetailHeader.tsx
+++ b/src/components/study-log-detail/LogDetailHeader.tsx
@@ -19,12 +19,14 @@ export default function LogDetailHeader({
   const showUpdatedAt = createdAt !== updatedAt
 
   return (
-    <header className="flex w-full max-w-4xl flex-col gap-6 rounded-t-xl border border-b-0 border-gray-200 p-6">
-      <section className="flex w-full flex-col justify-between sm:flex-row">
-        <H3>{title}</H3>
-        <div className="flex gap-2">
+    <header className="flex w-full max-w-4xl flex-col gap-10 rounded-t-xl border border-b-0 border-gray-200 p-4 sm:gap-6 sm:p-6">
+      <section className="flex w-full flex-col justify-between gap-4 wrap-normal sm:flex-row">
+        <H3 className="pb-8 text-xl wrap-anywhere sm:pb-0 sm:text-2xl">
+          {title}
+        </H3>
+        <div className="flex justify-between gap-2 sm:justify-end">
           <button
-            className="cursor-pointer rounded-lg bg-gray-100 px-3 py-1.5 hover:scale-105"
+            className="max-h-10 min-w-20 cursor-pointer rounded-lg bg-gray-100 px-3 py-1.5 hover:scale-105"
             onClick={onEdit}
           >
             <Text variant="small" className="font-medium text-gray-700">
@@ -32,7 +34,7 @@ export default function LogDetailHeader({
             </Text>
           </button>
           <button
-            className="cursor-pointer rounded-lg bg-red-100 px-3 py-1.5 hover:scale-105"
+            className="max-h-10 min-w-20 cursor-pointer rounded-lg bg-red-100 px-3 py-1.5 hover:scale-105"
             onClick={onDelete}
           >
             <Text variant="small" className="font-medium text-red-700">
@@ -42,7 +44,7 @@ export default function LogDetailHeader({
         </div>
       </section>
 
-      <section className="flex items-center gap-4">
+      <section className="flex flex-col items-center gap-1 sm:flex-row sm:gap-4">
         <div className="flex items-center gap-2">
           <Avatar
             size="sm"

--- a/src/components/study-log-detail/LogDetailMain.tsx
+++ b/src/components/study-log-detail/LogDetailMain.tsx
@@ -19,7 +19,7 @@ export default function LogDetailMain({ studyLogData }: LogDetailMainProps) {
 
   return (
     <main>
-      <section className="flex flex-col items-start justify-start border border-gray-200 p-6">
+      <section className="flex flex-col items-start justify-start border border-gray-200 p-4 sm:p-6">
         <MarkdownPreview value={content} />
       </section>
       <LogDetailAttachments

--- a/src/components/study-log/StudyLogLayout.tsx
+++ b/src/components/study-log/StudyLogLayout.tsx
@@ -18,7 +18,7 @@ export default function StudyLogLayout({
   return (
     <form onSubmit={onSubmit} className="w-full sm:max-w-4xl">
       {header}
-      <section className="flex flex-col items-start justify-start border-y border-gray-200 p-4 sm:rounded-xl sm:border sm:p-6">
+      <section className="flex flex-col items-start justify-start border-y border-gray-200 py-4 sm:rounded-xl sm:border sm:p-6">
         {title}
         {markdown}
       </section>

--- a/src/hooks/useAuthActions.ts
+++ b/src/hooks/useAuthActions.ts
@@ -8,13 +8,14 @@ export const useAuthActions = () => {
         email: 'admin@ozcoding.site',
         password: 'ozcoding0917!@',
       })
+      console.log('로그인 응답:', loginResponse)
 
       const tempUser = {
         uuid: 'leader-uuid-1234',
         nickname: '김개발',
       }
 
-      useAuthStore.getState().login(loginResponse.access, tempUser)
+      useAuthStore.getState().login(loginResponse.accessToken, tempUser)
     } catch (error) {
       // TODO: 토스트 알림 교체
       console.error('로그인 실패:', error)


### PR DESCRIPTION
## 🚀 PR 요약

> 로그 디테일 페이지 반응형 디자인 수정입니다


## ✏️ 변경 유형

- [x] style: 코드 포맷팅 등 스타일 변경

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

>
<img width="303" height="894" alt="image" src="https://github.com/user-attachments/assets/e3eae4cb-8c29-4073-ac07-2cb7b87d452a" />
<img width="283" height="657" alt="image" src="https://github.com/user-attachments/assets/71f31a7a-ac36-4d27-8305-cb6fd059f6b5" />
<img width="1503" height="890" alt="image" src="https://github.com/user-attachments/assets/c6fce4b0-2fc1-4428-82bd-b97eaace5223" />


## 🔗 연관된 이슈

> closes #254
