### PR TITLE
Refactor: 스터디 그룹 수정 폼 초기 데이터

### DIFF
--- a/src/components/create-study-group/form/StudyGroupFormContainer.tsx
+++ b/src/components/create-study-group/form/StudyGroupFormContainer.tsx
@@ -7,10 +7,11 @@ import {
   type StudyGroupFormValues,
 } from '@components'
 import { useStudyGroupMutations, useToast } from '@hooks'
-import { studyGroup } from '@mocks/datas/studyGroupDetail'
 import { buildCreateStudyGroupFormData } from '@utils'
 
 import type { Lecture } from '@models'
+import { useParams } from 'react-router'
+import { studyGroupList } from '@/mocks/datas/studygroupList'
 
 const INITIAL_MEMBER_COUNT = 6
 
@@ -33,11 +34,15 @@ export default function StudyGroupFormContainer({ mode }: FormMode) {
   const createStudyGroupMutation = useStudyGroupMutations()
   const { toast } = useToast()
 
+  const studyGroupUuid = useParams<{ groupId: string }>().groupId
+  const studyGroup =
+    studyGroupList.find((group) => group.uuid === studyGroupUuid) ||
+    studyGroupList[0]
+
   useEffect(() => {
     if (mode === 'edit') {
       reset({
         name: studyGroup.name,
-        introduction: studyGroup.introduction || '',
         startAt: studyGroup.startAt,
         endAt: studyGroup.endAt,
         currentHeadcount: studyGroup.currentHeadcount,


### PR DESCRIPTION
## 🚀 PR 요약

스터디 그룹 수정 폼 초기 데이터

## ✏️ 변경 유형

- [x] refactor: 코드 리팩토링

## ✅ 체크리스트

- [x] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [x] 커밋에 관련된 이슈 번호를 포함했습니다.
- [x] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 기타 참고사항

studyGroupList에서 groupId에 해당하는 스터디 그룹 데이터를 가져와 폼 초기화에 사용
<img width="654" height="836" alt="image" src="https://github.com/user-attachments/assets/10db0402-25c0-4c1f-803e-f47322813fb6" />


## 🔗 연관된 이슈

> closes #278
